### PR TITLE
Refactor waitid handling with WaitId enum

### DIFF
--- a/src/kernel/syscall/procops.rs
+++ b/src/kernel/syscall/procops.rs
@@ -7,7 +7,7 @@ use crate::kernel::constants::{
 use crate::kernel::mem::PageBuffer;
 use crate::kernel::task::{
     do_clone, futex_wait, futex_wake, FutexFlags, FutexOp, ProcessList, ProgramLoader,
-    RobustListHead, SignalAction, Thread, WaitType,
+    RobustListHead, SignalAction, Thread, WaitId, WaitType,
 };
 use crate::kernel::task::{parse_futexop, CloneArgs};
 use crate::kernel::timer::sleep;
@@ -26,7 +26,6 @@ use eonix_hal::traits::trap::RawTrapContext;
 use eonix_mm::address::{Addr as _, VAddr};
 use eonix_runtime::task::Task;
 use eonix_sync::AsProof as _;
-use posix_types::constants::{P_ALL, P_PID};
 use posix_types::ctypes::PtrT;
 use posix_types::signal::{SigAction, SigInfo, SigSet, Signal};
 use posix_types::stat::TimeVal;
@@ -215,16 +214,11 @@ enum WaitInfo {
 
 fn do_waitid(
     thread: &Thread,
-    id_type: u32,
-    _id: u32,
+    wait_id: WaitId,
     info: WaitInfo,
     options: u32,
     rusage: *mut RUsage,
 ) -> KResult<u32> {
-    if id_type != P_ALL {
-        unimplemented!("waitid with id_type {id_type}");
-    }
-
     if !rusage.is_null() {
         unimplemented!("waitid with rusage pointer");
     }
@@ -235,6 +229,7 @@ fn do_waitid(
     };
 
     let Some(wait_object) = Task::block_on(thread.process.wait(
+        wait_id,
         options.contains(UserWaitOptions::WNOHANG),
         options.contains(UserWaitOptions::WUNTRACED),
         options.contains(UserWaitOptions::WCONTINUED),
@@ -273,15 +268,10 @@ fn waitid(
     options: u32,
     rusage: *mut RUsage,
 ) -> KResult<u32> {
+    let wait_id = WaitId::from_type_and_id(id_type, id)?;
+
     if let Some(info) = NonNull::new(info) {
-        do_waitid(
-            thread,
-            id_type,
-            id,
-            WaitInfo::SigInfo(info),
-            options,
-            rusage,
-        )
+        do_waitid(thread, wait_id, WaitInfo::SigInfo(info), options, rusage)
     } else {
         /*
          * According to POSIX.1-2008, an application calling waitid() must
@@ -296,19 +286,16 @@ fn waitid(
 }
 
 #[eonix_macros::define_syscall(SYS_WAIT4)]
-fn wait4(waitpid: u32, arg1: *mut u32, options: u32, rusage: *mut RUsage) -> KResult<u32> {
+fn wait4(wait_id: i32, arg1: *mut u32, options: u32, rusage: *mut RUsage) -> KResult<u32> {
     let waitinfo = if let Some(status) = NonNull::new(arg1) {
         WaitInfo::Status(status)
     } else {
         WaitInfo::None
     };
 
-    let idtype = match waitpid {
-        u32::MAX => P_ALL,
-        _ => P_PID,
-    };
+    let wait_id = WaitId::from_id(wait_id, thread);
 
-    do_waitid(thread, idtype, waitpid, waitinfo, options, rusage)
+    do_waitid(thread, wait_id, waitinfo, options, rusage)
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/kernel/task.rs
+++ b/src/kernel/task.rs
@@ -13,7 +13,7 @@ pub use clone::{do_clone, CloneArgs, CloneFlags};
 pub use futex::{futex_wait, futex_wake, parse_futexop, FutexFlags, FutexOp, RobustListHead};
 pub use kernel_stack::KernelStack;
 pub use loader::ProgramLoader;
-pub use process::{alloc_pid, Process, ProcessBuilder, WaitObject, WaitType};
+pub use process::{alloc_pid, Process, ProcessBuilder, WaitId, WaitObject, WaitType};
 pub use process_group::ProcessGroup;
 pub use process_list::ProcessList;
 pub use session::Session;


### PR DESCRIPTION
Introduce a WaitId enum to streamline the handling of wait identifiers in the waitid function, enhancing clarity and maintainability of the code.