### PR TITLE
Pipeline build and test support

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Setup rust nightly
         run: rustup component add rust-src llvm-tools
 
+      - name: Setup QEMU
+        run: sudo apt-get install -y qemu-system-${{ matrix.arch }}
+
       - name: Configure
         run: ./configure
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -10,32 +10,49 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-build:
+  build-and-run-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [riscv64, loongarch64]
+        include:
+          - arch: riscv64
+            target: riscv64gc-unknown-none-elf
+          - arch: loongarch64
+            target: loongarch64-unknown-none-softfloat
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup rust nightly
         run: rustup component add rust-src llvm-tools
 
       - name: Configure
         run: ./configure
 
-      - name: Build for riscv64 targets
-        run: make build ARCH=riscv64 MODE=release
+      - name: Run build for ${{ matrix.arch }} targets
+        run: |
+          make build ARCH=${{ matrix.arch }} MODE=release
+          zstd -k build/boot-${{ matrix.arch }}.img
 
-      - name: Upload riscv64 build artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: kernel-riscv64
-          path: build/riscv64gc-unknown-none-elf/release/eonix_kernel
+          name: eonix-kernel-and-image-${{ matrix.arch }}
+          path: |
+            build/${{ matrix.target }}/release/eonix_kernel
+            build/boot-${{ matrix.arch }}.img.zst
 
-      - name: Build for loongarch64 targets
-        run: make build ARCH=loongarch64 MODE=release
+      - name: Test run for ${{ matrix.arch }}
+        run: sh script/test.sh
+        env:
+          ARCH: ${{ matrix.arch }}
+        timeout-minutes: 2
+        continue-on-error: true
 
-      - name: Upload loongarch64 build artifacts
+      - name: Upload run log
         uses: actions/upload-artifact@v4
         with:
-          name: kernel-loongarch64
-          path: build/loongarch64gc-unknown-none-elf/release/eonix_kernel
+          name: test-${{ matrix.arch }}.log
+          path: build/test-*.log

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,41 @@
+name: Test Build
+
+on:
+  push:
+    branches-ignore:
+      - comp-and-judge
+  pull_request:
+    branches-ignore:
+      - comp-and-judge
+  workflow_dispatch:
+
+jobs:
+  run-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup rust nightly
+        run: rustup component add rust-src llvm-tools
+
+      - name: Configure
+        run: ./configure
+
+      - name: Build for riscv64 targets
+        run: make build ARCH=riscv64 MODE=release
+
+      - name: Upload riscv64 build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-riscv64
+          path: build/riscv64gc-unknown-none-elf/release/eonix_kernel
+
+      - name: Build for loongarch64 targets
+        run: make build ARCH=loongarch64 MODE=release
+
+      - name: Upload loongarch64 build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-loongarch64
+          path: build/loongarch64gc-unknown-none-elf/release/eonix_kernel

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -29,7 +29,8 @@ jobs:
         run: rustup component add rust-src llvm-tools
 
       - name: Setup QEMU
-        run: sudo apt-get install -y qemu-system-${{ matrix.arch }}
+        run: |
+          sudo apt-get install -y qemu-system-${{ matrix.arch }} qemu-kvm
 
       - name: Configure
         run: ./configure
@@ -48,9 +49,13 @@ jobs:
             build/boot-${{ matrix.arch }}.img.zst
 
       - name: Test run for ${{ matrix.arch }}
-        run: sh script/test.sh
+        run: |
+          echo "Fixing permissions for /dev/kvm..."
+          sudo adduser $USER kvm
+          sh script/test.sh
         env:
           ARCH: ${{ matrix.arch }}
+          QEMU_ACCEL: ''
         timeout-minutes: 2
         continue-on-error: true
 

--- a/Makefile.src
+++ b/Makefile.src
@@ -27,7 +27,11 @@ CARGO_FLAGS := --profile $(PROFILE) --features $(FEATURES)$(if $(SMP),$(COMMA)sm
 ifeq ($(HOST),darwin)
 QEMU_ACCEL ?= -accel tcg
 else ifeq ($(HOST),linux)
+
+ifeq ($(shell ls /dev/kvm),/dev/kvm)
 QEMU_ACCEL ?= -accel kvm
+endif
+
 endif
 
 QEMU_ARGS += $(QEMU_ACCEL)

--- a/Makefile.src
+++ b/Makefile.src
@@ -21,7 +21,7 @@ KERNEL_SOURCES := $(shell find src macros crates -name '*.rs' -type f)
 KERNEL_CARGO_MANIFESTS += $(shell find src macros crates -name Cargo.toml -type f)
 KERNEL_DEPS := $(KERNEL_SOURCES) $(KERNEL_CARGO_MANIFESTS)
 
-QEMU_ARGS ?= -no-reboot -no-shutdown
+QEMU_ARGS ?= -no-reboot
 CARGO_FLAGS := --profile $(PROFILE) --features $(FEATURES)$(if $(SMP),$(COMMA)smp,)
 
 ifeq ($(HOST),darwin)
@@ -121,6 +121,10 @@ run: build build/kernel.sym
 .PHONY: srun
 srun: build build/kernel.sym
 	$(QEMU) $(QEMU_ARGS) -display none -S -s -serial mon:stdio
+
+.PHONY: test-run
+test-run: build
+	$(QEMU) $(QEMU_ARGS) -display none -serial stdio
 
 .PHONY: clean
 clean:

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+SUCCESS_MSG="###$RANDOM :SuCCeSS: $RANDOM###"
+
+if [ "$ARCH" = "" ]; then
+    echo "Error: ARCH environment variable is not set." >&2
+    exit 1
+fi
+
+printf "ls\necho \"$SUCCESS_MSG\"\npoweroff\n" \
+    | make test-run ARCH=$ARCH MODE=release \
+    | tee build/test-$$.log \
+    | grep "$SUCCESS_MSG" > /dev/null && echo TEST\ $$\ WITH\ ARCH=$ARCH\ PASSED

--- a/script/test.sh
+++ b/script/test.sh
@@ -8,6 +8,6 @@ if [ "$ARCH" = "" ]; then
 fi
 
 printf "ls\necho \"$SUCCESS_MSG\"\npoweroff\n" \
-    | make test-run ARCH=$ARCH MODE=release \
+    | make test-run ARCH=$ARCH MODE=release QEMU=qemu-system-$ARCH \
     | tee build/test-$$.log \
     | grep "$SUCCESS_MSG" > /dev/null && echo TEST\ $$\ WITH\ ARCH=$ARCH\ PASSED


### PR DESCRIPTION
We can now check for build status and run tests on CI. This can help us avoid the cases that some commits breaks everything up and we don't know that.