### PR TITLE
Add network stack support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94476c7ef97af4c4d998b3f422c1b01d5211aad57c80ed200baf148d1f1efab6"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 2.9.1",
  "log",
 ]
 
@@ -18,6 +18,17 @@ name = "align_ext"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c330e503236d0b06386ae6cc42a513ef1ccc23c52b603c1b52f018564faf44"
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic_unique_refcell"
@@ -37,6 +48,12 @@ checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -50,6 +67,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +89,47 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "defmt"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "either"
@@ -95,7 +165,7 @@ name = "eonix_hal"
 version = "0.1.0"
 dependencies = [
  "acpi",
- "bitflags",
+ "bitflags 2.9.1",
  "buddy_allocator",
  "cfg-if",
  "eonix_hal_macros",
@@ -124,7 +194,7 @@ dependencies = [
 name = "eonix_hal_traits"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "eonix_mm",
 ]
 
@@ -134,9 +204,11 @@ version = "0.1.0"
 dependencies = [
  "acpi",
  "align_ext",
+ "async-trait",
  "atomic_unique_refcell",
- "bitflags",
+ "bitflags 2.9.1",
  "buddy_allocator",
+ "bytes",
  "eonix_hal",
  "eonix_log",
  "eonix_macros",
@@ -152,6 +224,7 @@ dependencies = [
  "pointers",
  "posix_types",
  "slab_allocator",
+ "smoltcp",
  "virtio-drivers",
  "xmas-elf",
 ]
@@ -176,7 +249,7 @@ dependencies = [
 name = "eonix_mm"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -254,7 +327,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1a97344bde15b0ace15e265dab27228d4bdc37a0bfa8548c5645d7cfa6a144"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "log",
 ]
 
@@ -263,6 +336,45 @@ name = "fdt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "int-to-c-enum"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24dde2fe29de031a6fc24642ea1a62cb8e273b6c9e8799fa5c7cf0e2f03f220"
+dependencies = [
+ "int-to-c-enum-derive",
+]
+
+[[package]]
+name = "int-to-c-enum-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1b8cfab94604ae1bcab8af8dd04cac15568a95cff50c562e6108457022f49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "intrusive-collections"
@@ -299,8 +411,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9f0d275c70310e2a9d2fc23250c5ac826a73fa828a5f256401f85c5c554283"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memoffset"
@@ -325,8 +443,31 @@ version = "0.1.0"
 name = "posix_types"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
+ "int-to-c-enum",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -402,6 +543,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoltcp"
+version = "0.12.0"
+source = "git+https://github.com/Shao-ZW/smoltcp.git?rev=023817e#023817ec11c96d87d83256d3df9f10015828d9d0"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if",
+ "defmt 0.3.100",
+ "heapless",
+ "managed",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,7 +604,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe3f779fd88436e27b51540d9563c7454c8c814893a1e6f9bb6138bcac60627"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "embedded-io",
  "enumn",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ pointers = { path = "./crates/pointers" }
 posix_types = { path = "./crates/posix_types" }
 slab_allocator = { path = "./crates/slab_allocator" }
 
+async-trait = "0.1.80"
+bytes = { version = "1.10.0", default-features = false }
 bitflags = "2.6.0"
 intrusive-collections = "0.9.7"
 itertools = { version = "0.13.0", default-features = false }
@@ -31,6 +33,24 @@ acpi = "5.2.0"
 align_ext = "0.1.0"
 xmas-elf = "0.10.0"
 ext4_rs = "1.3.2"
+
+[dependencies.smoltcp]
+git = "https://github.com/Shao-ZW/smoltcp.git"
+rev = "023817e"
+default-features = false
+features = [
+    "alloc",
+    "medium-ethernet",
+    "medium-ip",
+    "proto-ipv4",
+    "proto-ipv6",
+    "socket-raw",
+    "socket-icmp",
+    "socket-udp",
+    "socket-tcp",
+    "socket-dns",
+    "async",
+]
 
 [target.'cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))'.dependencies]
 virtio-drivers = { version = "0.11.0" }

--- a/crates/posix_types/Cargo.toml
+++ b/crates/posix_types/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 cfg-if = "1.0"
 bitflags = "2.6.0"
+int-to-c-enum = "0.1.0"

--- a/crates/posix_types/src/lib.rs
+++ b/crates/posix_types/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod constants;
 pub mod ctypes;
 pub mod namei;
+pub mod net;
 pub mod open;
 pub mod poll;
 pub mod result;

--- a/crates/posix_types/src/net.rs
+++ b/crates/posix_types/src/net.rs
@@ -1,0 +1,223 @@
+use core::net::Ipv4Addr;
+
+use bitflags::bitflags;
+use int_to_c_enum::TryFromInt;
+
+// definition copy from asterinas
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromInt)]
+#[expect(non_camel_case_types)]
+pub enum SockDomain {
+    AF_UNSPEC = 0,
+    /// Unix domain sockets
+    AF_UNIX = 1,
+    // POSIX name for AF_UNIX
+    // AF_LOCAL = 1,
+    /// Internet IP Protocol
+    AF_INET = 2,
+    /// Amateur Radio AX.25
+    AF_AX25 = 3,
+    /// Novell IPX
+    AF_IPX = 4,
+    /// AppleTalk DDP
+    AF_APPLETALK = 5,
+    /// Amateur Radio NET/ROM
+    AF_NETROM = 6,
+    /// Multiprotocol bridge
+    AF_BRIDGE = 7,
+    /// ATM PVCs
+    AF_ATMPVC = 8,
+    /// Reserved for X.25 project
+    AF_X25 = 9,
+    /// IP version 6,
+    AF_INET6 = 10,
+    /// Amateur Radio X.25 PLP
+    AF_ROSE = 11,
+    /// Reserved for DECnet project
+    AF_DECnet = 12,
+    /// Reserved for 802.2LLC project
+    AF_NETBEUI = 13,
+    /// Security callback pseudo AF
+    AF_SECURITY = 14,
+    /// PF_KEY key management API
+    AF_KEY = 15,
+    AF_NETLINK = 16,
+    // Alias to emulate 4.4BSD
+    // AF_ROUTE = AF_NETLINK
+    /// Packet family
+    AF_PACKET = 17,
+    /// Ash
+    AF_ASH = 18,
+    /// Acorn Econet
+    AF_ECONET = 19,
+    /// ATM SVCs
+    AF_ATMSVC = 20,
+    /// RDS sockets
+    AF_RDS = 21,
+    /// Linux SNA Project (nutters!)
+    AF_SNA = 22,
+    /// IRDA sockets
+    AF_IRDA = 23,
+    /// PPPoX sockets
+    AF_PPPOX = 24,
+    /// Wanpipe API Sockets
+    AF_WANPIPE = 25,
+    /// Linux LLC
+    AF_LLC = 26,
+    /// Native InfiniBand address
+    AF_IB = 27,
+    /// MPLS
+    AF_MPLS = 28,
+    /// Controller Area Network
+    AF_CAN = 29,
+    /// TIPC sockets
+    AF_TIPC = 30,
+    /// Bluetooth sockets
+    AF_BLUETOOTH = 31,
+    /// IUCV sockets
+    AF_IUCV = 32,
+    /// RxRPC sockets
+    AF_RXRPC = 33,
+    /// mISDN sockets
+    AF_ISDN = 34,
+    /// Phonet sockets
+    AF_PHONET = 35,
+    /// IEEE802154 sockets
+    AF_IEEE802154 = 36,
+    /// CAIF sockets
+    AF_CAIF = 37,
+    /// Algorithm sockets
+    AF_ALG = 38,
+    /// NFC sockets
+    AF_NFC = 39,
+    /// vSockets
+    AF_VSOCK = 40,
+    /// Kernel Connection Multiplexor
+    AF_KCM = 41,
+    /// Qualcomm IPC Router
+    AF_QIPCRTR = 42,
+    /// smc sockets: reserve number for
+    /// PF_SMC protocol family that
+    /// reuses AF_INET address family
+    AF_SMC = 43,
+    /// XDP sockets
+    AF_XDP = 44,
+    /// Management component transport protocol
+    AF_MCTP = 45,
+}
+
+pub const SOCK_TYPE_MASK: u32 = 0xf;
+
+bitflags! {
+    #[repr(C)]
+    pub struct SockFlags: u32 {
+        const SOCK_NONBLOCK = 1 << 11;
+        const SOCK_CLOEXEC = 1 << 19;
+    }
+}
+
+#[repr(u32)]
+#[expect(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, TryFromInt)]
+pub enum SockType {
+    /// Stream socket
+    SOCK_STREAM = 1,
+    /// Datagram socket
+    SOCK_DGRAM = 2,
+    /// Raw socket
+    SOCK_RAW = 3,
+    /// Reliably-delivered message
+    SOCK_RDM = 4,
+    /// Sequential packet socket
+    SOCK_SEQPACKET = 5,
+    /// Datagram Congestion Control Protocol socket
+    SOCK_DCCP = 6,
+    /// Linux specific way of getting packets at the dev level
+    SOCK_PACKET = 10,
+}
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, TryFromInt)]
+#[expect(non_camel_case_types)]
+pub enum Protocol {
+    IPPROTO_IP = 0,         /* Dummy protocol for TCP		*/
+    IPPROTO_ICMP = 1,       /* Internet Control Message Protocol	*/
+    IPPROTO_IGMP = 2,       /* Internet Group Management Protocol	*/
+    IPPROTO_TCP = 6,        /* Transmission Control Protocol	*/
+    IPPROTO_EGP = 8,        /* Exterior Gateway Protocol		*/
+    IPPROTO_PUP = 12,       /* PUP protocol				*/
+    IPPROTO_UDP = 17,       /* User Datagram Protocol		*/
+    IPPROTO_IDP = 22,       /* XNS IDP protocol			*/
+    IPPROTO_TP = 29,        /* SO Transport Protocol Class 4	*/
+    IPPROTO_DCCP = 33,      /* Datagram Congestion Control Protocol */
+    IPPROTO_IPV6 = 41,      /* IPv6-in-IPv4 tunnelling		*/
+    IPPROTO_RSVP = 46,      /* RSVP Protocol			*/
+    IPPROTO_GRE = 47,       /* Cisco GRE tunnels (rfc 1701,1702)	*/
+    IPPROTO_ESP = 50,       /* Encapsulation Security Payload protocol */
+    IPPROTO_AH = 51,        /* Authentication Header protocol	*/
+    IPPROTO_MTP = 92,       /* Multicast Transport Protocol		*/
+    IPPROTO_BEETPH = 94,    /* IP option pseudo header for BEET	*/
+    IPPROTO_ENCAP = 98,     /* Encapsulation Header			*/
+    IPPROTO_PIM = 103,      /* Protocol Independent Multicast	*/
+    IPPROTO_COMP = 108,     /* Compression Header Protocol		*/
+    IPPROTO_SCTP = 132,     /* Stream Control Transport Protocol	*/
+    IPPROTO_UDPLITE = 136,  /* UDP-Lite (RFC 3828)			*/
+    IPPROTO_MPLS = 137,     /* MPLS in IP (RFC 4023)		*/
+    IPPROTO_ETHERNET = 143, /* Ethernet-within-IPv6 Encapsulation	*/
+    IPPROTO_RAW = 255,      /* Raw IP packets			*/
+    IPPROTO_MPTCP = 262,    /* Multipath TCP connection		*/
+}
+
+pub const ADDR_MAX_LEN: usize = 128;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CSockAddr {
+    pub sa_family: u16,
+    pub bytes: [u8; ADDR_MAX_LEN - 2],
+    pub _align: [u64; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CSocketAddrInet {
+    /// Address family (AF_INET).
+    sin_family: u16,
+    /// Port number.
+    sin_port: u16,
+    /// IPv4 address.
+    sin_addr: u32,
+    /// Pad bytes to 16-byte `struct sockaddr`.
+    sin_zero: [u8; 8],
+}
+
+impl CSocketAddrInet {
+    pub fn new(addr: Ipv4Addr, port: u16) -> Self {
+        Self {
+            sin_family: 2, // AF_INET = 2,
+            sin_port: port.to_be(),
+            sin_addr: u32::from_ne_bytes(addr.octets()),
+            sin_zero: [0; 8],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct MsgHdr {
+    /// Pointer to socket address structure
+    pub msg_name: usize,
+    /// Size of socket address
+    pub msg_namelen: i32,
+    /// Scatter/Gather iov array
+    pub msg_iov: usize,
+    /// The # of elements in msg_iov
+    pub msg_iovlen: u32,
+    /// Ancillary data
+    pub msg_control: usize,
+    /// Ancillary data buffer length
+    pub msg_controllen: u32,
+    /// Flags on received message
+    pub msg_flags: u32,
+}

--- a/crates/posix_types/src/open.rs
+++ b/crates/posix_types/src/open.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 
 bitflags! {
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, Default)]
     pub struct OpenFlags: u32 {
         /// Open for writing only
         const O_WRONLY = 0x1;
@@ -25,13 +25,13 @@ bitflags! {
         const O_CLOEXEC = 0x80000;
     }
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, Default)]
     pub struct FDFlags: u32 {
         /// Close on exec
         const FD_CLOEXEC = 0x1;
     }
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, Default)]
     pub struct AtFlags: u32 {
         /// Do not follow symbolic links
         const AT_SYMLINK_NOFOLLOW = 0x100;

--- a/src/driver/virtio.rs
+++ b/src/driver/virtio.rs
@@ -1,4 +1,6 @@
+mod hal;
 mod virtio_blk;
+mod virtio_net;
 
 #[cfg(not(any(target_arch = "riscv64", target_arch = "loongarch64")))]
 compile_error!("VirtIO drivers are only supported on RISC-V and LoongArch64 architecture");

--- a/src/driver/virtio/hal.rs
+++ b/src/driver/virtio/hal.rs
@@ -1,0 +1,66 @@
+use crate::kernel::mem::{AsMemoryBlock, Page};
+use eonix_hal::mm::ArchPhysAccess;
+use eonix_mm::{
+    address::{Addr, PAddr, PhysAccess},
+    paging::PFN,
+};
+use virtio_drivers::Hal;
+
+pub struct HAL;
+
+unsafe impl Hal for HAL {
+    fn dma_alloc(
+        pages: usize,
+        _direction: virtio_drivers::BufferDirection,
+    ) -> (virtio_drivers::PhysAddr, core::ptr::NonNull<u8>) {
+        let page = Page::alloc_at_least(pages);
+
+        let paddr = page.start().addr();
+        let ptr = page.as_memblk().as_byte_ptr();
+        page.into_raw();
+
+        (paddr, ptr)
+    }
+
+    unsafe fn dma_dealloc(
+        paddr: virtio_drivers::PhysAddr,
+        _vaddr: core::ptr::NonNull<u8>,
+        _pages: usize,
+    ) -> i32 {
+        let pfn = PFN::from(PAddr::from(paddr));
+
+        unsafe {
+            // SAFETY: The caller ensures that the pfn corresponds to a valid
+            //         page allocated by `dma_alloc`.
+            Page::from_raw(pfn);
+        }
+
+        0
+    }
+
+    unsafe fn mmio_phys_to_virt(
+        paddr: virtio_drivers::PhysAddr,
+        _size: usize,
+    ) -> core::ptr::NonNull<u8> {
+        unsafe { ArchPhysAccess::as_ptr(PAddr::from(paddr)) }
+    }
+
+    unsafe fn share(
+        buffer: core::ptr::NonNull<[u8]>,
+        _direction: virtio_drivers::BufferDirection,
+    ) -> virtio_drivers::PhysAddr {
+        let paddr = unsafe {
+            // SAFETY: The caller ensures that the buffer is valid.
+            ArchPhysAccess::from_ptr(buffer.cast::<u8>())
+        };
+
+        paddr.addr()
+    }
+
+    unsafe fn unshare(
+        _paddr: virtio_drivers::PhysAddr,
+        _buffer: core::ptr::NonNull<[u8]>,
+        _direction: virtio_drivers::BufferDirection,
+    ) {
+    }
+}

--- a/src/driver/virtio/riscv64.rs
+++ b/src/driver/virtio/riscv64.rs
@@ -1,23 +1,18 @@
-use super::virtio_blk::HAL;
-use crate::kernel::{
-    block::{make_device, BlockDevice},
-    mem::{AsMemoryBlock, MemoryBlock, Page},
+use crate::{
+    driver::virtio::hal::HAL,
+    kernel::block::{make_device, BlockDevice},
+    net,
 };
 use alloc::{sync::Arc, vec::Vec};
-use core::num::NonZero;
 use eonix_hal::arch_exported::fdt::FDT;
 use eonix_hal::mm::ArchPhysAccess;
 use eonix_log::{println_info, println_warn};
-use eonix_mm::{
-    address::{Addr, PAddr, PhysAccess},
-    paging::PFN,
-};
+use eonix_mm::address::{PAddr, PhysAccess};
 use eonix_runtime::task::Task;
 use eonix_sync::Spin;
 use virtio_drivers::{
-    device::blk::VirtIOBlk,
+    device::{blk::VirtIOBlk, net::VirtIONet},
     transport::{mmio::MmioTransport, Transport},
-    Hal,
 };
 
 pub fn init() {
@@ -61,11 +56,12 @@ pub fn init() {
                     disk_id += 1;
                 }
                 virtio_drivers::transport::DeviceType::Network => {
-                    println_info!(
-                        "Initializing Virtio Network device at {:?} with size {:#x}",
-                        base,
-                        size
-                    );
+                    const NET_QUEUE_SIZE: usize = 64;
+                    const NET_BUF_LEN: usize = 2048;
+                    let net_device =
+                        VirtIONet::<HAL, _, NET_QUEUE_SIZE>::new(transport, NET_BUF_LEN)
+                            .expect("Failed to initialize VirtIO Net device");
+                    net::register_netdev(net_device).expect("Failed to register VirtIO Net device");
                 }
                 virtio_drivers::transport::DeviceType::Console => {
                     println_info!(

--- a/src/driver/virtio/virtio_blk.rs
+++ b/src/driver/virtio/virtio_blk.rs
@@ -1,78 +1,15 @@
 use crate::{
+    driver::virtio::hal::HAL,
     io::Chunks,
     kernel::{
         block::{BlockDeviceRequest, BlockRequestQueue},
         constants::EIO,
-        mem::{AsMemoryBlock, Page},
+        mem::AsMemoryBlock,
     },
     prelude::KResult,
 };
-use eonix_hal::mm::ArchPhysAccess;
-use eonix_mm::{
-    address::{Addr, PAddr, PhysAccess},
-    paging::PFN,
-};
 use eonix_sync::Spin;
-use virtio_drivers::{device::blk::VirtIOBlk, transport::Transport, Hal};
-
-pub struct HAL;
-
-unsafe impl Hal for HAL {
-    fn dma_alloc(
-        pages: usize,
-        _direction: virtio_drivers::BufferDirection,
-    ) -> (virtio_drivers::PhysAddr, core::ptr::NonNull<u8>) {
-        let page = Page::alloc_at_least(pages);
-
-        let paddr = page.start().addr();
-        let ptr = page.as_memblk().as_byte_ptr();
-        page.into_raw();
-
-        (paddr, ptr)
-    }
-
-    unsafe fn dma_dealloc(
-        paddr: virtio_drivers::PhysAddr,
-        _vaddr: core::ptr::NonNull<u8>,
-        _pages: usize,
-    ) -> i32 {
-        let pfn = PFN::from(PAddr::from(paddr));
-
-        unsafe {
-            // SAFETY: The caller ensures that the pfn corresponds to a valid
-            //         page allocated by `dma_alloc`.
-            Page::from_raw(pfn);
-        }
-
-        0
-    }
-
-    unsafe fn mmio_phys_to_virt(
-        paddr: virtio_drivers::PhysAddr,
-        _size: usize,
-    ) -> core::ptr::NonNull<u8> {
-        unsafe { ArchPhysAccess::as_ptr(PAddr::from(paddr)) }
-    }
-
-    unsafe fn share(
-        buffer: core::ptr::NonNull<[u8]>,
-        _direction: virtio_drivers::BufferDirection,
-    ) -> virtio_drivers::PhysAddr {
-        let paddr = unsafe {
-            // SAFETY: The caller ensures that the buffer is valid.
-            ArchPhysAccess::from_ptr(buffer.cast::<u8>())
-        };
-
-        paddr.addr()
-    }
-
-    unsafe fn unshare(
-        _paddr: virtio_drivers::PhysAddr,
-        _buffer: core::ptr::NonNull<[u8]>,
-        _direction: virtio_drivers::BufferDirection,
-    ) {
-    }
-}
+use virtio_drivers::{device::blk::VirtIOBlk, transport::Transport};
 
 impl<T> BlockRequestQueue for Spin<VirtIOBlk<HAL, T>>
 where

--- a/src/driver/virtio/virtio_net.rs
+++ b/src/driver/virtio/virtio_net.rs
@@ -1,0 +1,46 @@
+use crate::driver::virtio::hal::HAL;
+use crate::net::device::{Mac, NetDev, NetDevError};
+use smoltcp::phy::{DeviceCapabilities, Medium};
+
+use virtio_drivers::device::net::{RxBuffer, TxBuffer};
+use virtio_drivers::{device::net::VirtIONet, transport::Transport};
+
+static VIRTIO_NET_NAME: &'static str = "virtio_net";
+
+impl<T, const QUEUE_SIZE: usize> NetDev for VirtIONet<HAL, T, QUEUE_SIZE>
+where
+    T: Transport + Send + Sync,
+{
+    fn name(&self) -> &'static str {
+        VIRTIO_NET_NAME
+    }
+
+    fn mac_addr(&self) -> Mac {
+        self.mac_address()
+    }
+
+    fn caps(&self) -> DeviceCapabilities {
+        let mut caps = DeviceCapabilities::default();
+        caps.max_transmission_unit = 1514;
+        caps.max_burst_size = None;
+        caps.medium = Medium::Ethernet;
+        caps
+    }
+
+    fn can_receive(&self) -> bool {
+        self.can_recv()
+    }
+
+    fn can_send(&self) -> bool {
+        self.can_send()
+    }
+
+    fn recv(&mut self) -> Result<RxBuffer, NetDevError> {
+        self.receive().map_err(|_| NetDevError::Unknown)
+    }
+
+    fn send(&mut self, data: &[u8]) -> Result<(), NetDevError> {
+        self.send(TxBuffer::from(data))
+            .map_err(|_| NetDevError::Unknown)
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -30,7 +30,7 @@ impl FillResult {
     }
 }
 
-pub trait Buffer {
+pub trait Buffer: Send {
     fn total(&self) -> usize;
     fn wrote(&self) -> usize;
 
@@ -49,7 +49,7 @@ pub trait Buffer {
     }
 }
 
-pub trait Stream {
+pub trait Stream: Send {
     fn poll_data<'a>(&mut self, buf: &'a mut [u8]) -> KResult<Option<&'a mut [u8]>>;
     fn ignore(&mut self, len: usize) -> KResult<Option<usize>>;
 }
@@ -161,7 +161,7 @@ impl<'lt, T: Copy + Sized> UninitBuffer<'lt, T> {
     }
 }
 
-impl<'lt, T: Copy + Sized> Buffer for UninitBuffer<'lt, T> {
+impl<'lt, T: Copy + Sized + Send> Buffer for UninitBuffer<'lt, T> {
     fn total(&self) -> usize {
         self.buffer.total()
     }

--- a/src/kernel/constants.rs
+++ b/src/kernel/constants.rs
@@ -44,6 +44,14 @@ pub const ERANGE: u32 = 34;
 pub const ENOSYS: u32 = 38;
 pub const ELOOP: u32 = 40;
 pub const EOVERFLOW: u32 = 75;
+pub const ENOTSOCK: u32 = 88;
+pub const EAFNOSUPPORT: u32 = 97;
+pub const EADDRINUSE: u32 = 98;
+pub const EADDRNOTAVAIL: u32 = 99;
+pub const ECONNRESET: u32 = 104;
+pub const EISCONN: u32 = 106;
+pub const ENOTCONN: u32 = 107;
+pub const ECONNREFUSED: u32 = 111;
 
 // pub const S_IFIFO: u32 = 0o010000;
 pub const S_IFCHR: u32 = 0o020000;

--- a/src/kernel/mem/page_cache.rs
+++ b/src/kernel/mem/page_cache.rs
@@ -26,6 +26,8 @@ unsafe impl Sync for PageCache {}
 #[derive(Clone, Copy)]
 pub struct CachePage(RawPagePtr);
 
+unsafe impl Send for CachePage {}
+
 impl Buffer for CachePage {
     fn total(&self) -> usize {
         PAGE_SIZE

--- a/src/kernel/syscall/file_rw.rs
+++ b/src/kernel/syscall/file_rw.rs
@@ -362,9 +362,9 @@ fn llseek(fd: FD, offset_high: u32, offset_low: u32, result: *mut u64, whence: u
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-struct IoVec {
-    base: PtrT,
-    len: Long,
+pub struct IoVec {
+    pub base: PtrT,
+    pub len: Long,
 }
 
 #[eonix_macros::define_syscall(SYS_READV)]
@@ -550,7 +550,7 @@ fn pselect6(
     }
 
     let timeout = UserPointerMut::new(timeout)?;
-    
+
     // Read here to check for invalid pointers.
     let _timeout_value = timeout.read()?;
 

--- a/src/kernel/syscall/net.rs
+++ b/src/kernel/syscall/net.rs
@@ -1,10 +1,273 @@
-use crate::kernel::constants::EINVAL;
+use core::net::IpAddr;
+use core::net::Ipv4Addr;
+use core::net::SocketAddr;
+
+use crate::io::Buffer;
+use crate::io::IntoStream;
+use crate::kernel::constants::{EAFNOSUPPORT, EBADF, EINVAL, ENOTSOCK};
+use crate::kernel::syscall::file_rw::IoVec;
+use crate::kernel::user::dataflow::CheckedUserPointer;
+use crate::kernel::user::UserBuffer;
+use crate::kernel::user::UserPointer;
+use crate::kernel::user::UserPointerMut;
+use crate::kernel::vfs::filearray::FD;
+use crate::net::socket::tcp::TcpSocket;
 use crate::prelude::*;
+use bytes::Buf;
+use eonix_runtime::task::Task;
+use posix_types::ctypes::Long;
+use posix_types::net::CSocketAddrInet;
+use posix_types::net::{
+    CSockAddr, MsgHdr, Protocol, SockDomain, SockFlags, SockType, ADDR_MAX_LEN, SOCK_TYPE_MASK,
+};
 use posix_types::syscall_no::*;
 
+fn read_socket_addr(addr_ptr: *const CSockAddr, addrlen: usize) -> KResult<SocketAddr> {
+    if addrlen > ADDR_MAX_LEN || addrlen < 2 {
+        return Err(EINVAL);
+    }
+
+    let raw_sockaddr = UserPointer::new(addr_ptr)?.read()?;
+
+    match SockDomain::try_from(raw_sockaddr.sa_family as u32) {
+        Ok(SockDomain::AF_INET) => {
+            if addrlen < size_of::<SockDomain>() {
+                return Err(EINVAL);
+            }
+
+            let mut bytes = raw_sockaddr.bytes.as_slice();
+            let port = bytes.get_u16();
+            let addr_bits = bytes.get_u32();
+            let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::from_bits(addr_bits)), port);
+            Ok(socket_addr)
+        }
+        _ => Err(EAFNOSUPPORT),
+    }
+}
+
+fn write_socket_addr(
+    addr_ptr: *mut CSockAddr,
+    addrlen_ptr: *mut u32,
+    socket_addr: SocketAddr,
+) -> KResult<()> {
+    match socket_addr {
+        SocketAddr::V4(addr) => {
+            let raw_socket = CSocketAddrInet::new(*addr.ip(), addr.port());
+            UserPointerMut::new(addr_ptr as *mut CSocketAddrInet)?.write(raw_socket)?;
+            UserPointerMut::new(addrlen_ptr)?.write(size_of::<CSocketAddrInet>() as u32)?;
+            Ok(())
+        }
+        SocketAddr::V6(_) => panic!("IPv6 is not supported"),
+    }
+}
+
 #[eonix_macros::define_syscall(SYS_SOCKET)]
-fn socket(_domain: u32, _socket_type: u32, _protocol: u32) -> KResult<u32> {
-    Err(EINVAL)
+fn socket(domain: u32, type_: u32, protocol: u32) -> KResult<FD> {
+    let domain = SockDomain::try_from(domain).map_err(|_| EINVAL)?;
+    let sock_type = SockType::try_from(type_ & SOCK_TYPE_MASK).map_err(|_| EINVAL)?;
+    let sock_flags = SockFlags::from_bits_truncate(type_ & !SOCK_TYPE_MASK);
+    let protocol = Protocol::try_from(protocol).map_err(|_| EINVAL)?;
+
+    let is_nonblock = sock_flags.contains(SockFlags::SOCK_NONBLOCK);
+
+    let socket = match (domain, sock_type) {
+        (SockDomain::AF_INET, SockType::SOCK_STREAM) => match protocol {
+            Protocol::IPPROTO_IP | Protocol::IPPROTO_TCP => TcpSocket::new(is_nonblock),
+            _ => return Err(EAFNOSUPPORT),
+        },
+        (SockDomain::AF_INET, SockType::SOCK_DGRAM) => {
+            panic!("unsupported udp now")
+        }
+        _ => panic!("unsupported socket"),
+    };
+
+    thread.files.socket(socket)
+}
+
+#[eonix_macros::define_syscall(SYS_BIND)]
+fn bind(sockfd: FD, sockaddr_ptr: *const CSockAddr, addrlen: u32) -> KResult<()> {
+    let socket = thread
+        .files
+        .get(sockfd)
+        .ok_or(EBADF)?
+        .get_socket()?
+        .ok_or(ENOTSOCK)?;
+
+    let socket_addr = read_socket_addr(sockaddr_ptr, addrlen as usize)?;
+
+    socket.bind(socket_addr)
+}
+
+#[eonix_macros::define_syscall(SYS_LISTEN)]
+fn listen(sockfd: FD, backlog: u32) -> KResult<()> {
+    let socket = thread
+        .files
+        .get(sockfd)
+        .ok_or(EBADF)?
+        .get_socket()?
+        .ok_or(ENOTSOCK)?;
+
+    socket.listen(backlog as usize)
+}
+
+#[eonix_macros::define_syscall(SYS_ACCEPT)]
+fn accept(sockfd: FD, sockaddr_ptr: *mut CSockAddr, addrlen_ptr: *mut u32) -> KResult<FD> {
+    let socket = thread
+        .files
+        .get(sockfd)
+        .ok_or(EBADF)?
+        .get_socket()?
+        .ok_or(ENOTSOCK)?;
+
+    let (accepted_socket, remote_addr) = Task::block_on(socket.accept())?;
+    write_socket_addr(sockaddr_ptr, addrlen_ptr, remote_addr)?;
+    thread.files.socket(accepted_socket)
+}
+
+#[eonix_macros::define_syscall(SYS_CONNECT)]
+fn connect(sockfd: FD, sockaddr_ptr: *const CSockAddr, addrlen: u32) -> KResult<()> {
+    let socket = thread
+        .files
+        .get(sockfd)
+        .ok_or(EBADF)?
+        .get_socket()?
+        .ok_or(ENOTSOCK)?;
+
+    let remote_addr = read_socket_addr(sockaddr_ptr, addrlen as usize)?;
+
+    Task::block_on(socket.connect(remote_addr))
+}
+
+#[eonix_macros::define_syscall(SYS_RECVMSG)]
+fn recvmsg(sockfd: FD, msghdr: *mut MsgHdr, flags: u32) -> KResult<usize> {
+    let socket = thread
+        .files
+        .get(sockfd)
+        .ok_or(EBADF)?
+        .get_socket()?
+        .ok_or(ENOTSOCK)?;
+
+    let msghdr = UserPointer::new(msghdr)?.read()?;
+
+    let mut iov_user = UserPointer::new(msghdr.msg_iov as *mut IoVec)?;
+    let iov_buffers = (0..msghdr.msg_iovlen)
+        .map(|_| {
+            let iov_result = iov_user.read()?;
+            iov_user = iov_user.offset(1)?;
+            Ok(iov_result)
+        })
+        .filter_map(|iov_result| match iov_result {
+            Err(err) => Some(Err(err)),
+            Ok(IoVec {
+                len: Long::ZERO, ..
+            }) => None,
+            Ok(IoVec { base, len }) => Some(UserBuffer::new(base.addr() as *mut u8, len.get())),
+        })
+        .collect::<KResult<Vec<_>>>()?;
+
+    let mut tot = 0usize;
+    for mut buffer in iov_buffers.into_iter() {
+        let nread = Task::block_on(socket.recv(&mut buffer))?;
+        tot += nread;
+
+        if nread != buffer.total() {
+            break;
+        }
+    }
+
+    // FIXME: should write some data to msghdr
+
+    Ok(tot)
+}
+
+#[eonix_macros::define_syscall(SYS_RECVFROM)]
+fn recvfrom(
+    sockfd: FD,
+    buf: *mut u8,
+    len: usize,
+    flags: u32,
+    srcaddr_ptr: *mut CSockAddr,
+    addrlen_ptr: *mut u32,
+) -> KResult<usize> {
+    let socket = thread
+        .files
+        .get(sockfd)
+        .ok_or(EBADF)?
+        .get_socket()?
+        .ok_or(ENOTSOCK)?;
+
+    let ret = Task::block_on(socket.recv(&mut UserBuffer::new(buf, len)?))?;
+
+    // FIXME: should write some data to srcaddr and addrlen
+
+    Ok(ret)
+}
+
+#[eonix_macros::define_syscall(SYS_SENDMSG)]
+fn sendmsg(sockfd: FD, msghdr: *const MsgHdr, flags: u32) -> KResult<usize> {
+    let socket = thread
+        .files
+        .get(sockfd)
+        .ok_or(EBADF)?
+        .get_socket()?
+        .ok_or(ENOTSOCK)?;
+
+    let msghdr = UserPointer::new(msghdr)?.read()?;
+
+    let mut iov_user = UserPointer::new(msghdr.msg_iov as *const IoVec)?;
+    let iov_streams = (0..msghdr.msg_iovlen)
+        .map(|_| {
+            let iov_result = iov_user.read()?;
+            iov_user = iov_user.offset(1)?;
+            Ok(iov_result)
+        })
+        .filter_map(|iov_result| match iov_result {
+            Err(err) => Some(Err(err)),
+            Ok(IoVec {
+                len: Long::ZERO, ..
+            }) => None,
+            Ok(IoVec { base, len }) => Some(
+                CheckedUserPointer::new(base.addr() as *mut u8, len.get())
+                    .map(|ptr| ptr.into_stream()),
+            ),
+        })
+        .collect::<KResult<Vec<_>>>()?;
+
+    // FIXME: Ignore lot of message in msghdr
+
+    let mut tot = 0usize;
+    for mut stream in iov_streams.into_iter() {
+        let nread = Task::block_on(socket.send(&mut stream))?;
+        tot += nread;
+
+        if nread == 0 || !stream.is_drained() {
+            break;
+        }
+    }
+
+    Ok(tot)
+}
+
+#[eonix_macros::define_syscall(SYS_SENDTO)]
+fn sendto(
+    sockfd: FD,
+    buf: *const u8,
+    len: usize,
+    flags: u32,
+    dstaddr_ptr: *const CSockAddr,
+    addrlen: u32,
+) -> KResult<usize> {
+    let socket = thread
+        .files
+        .get(sockfd)
+        .ok_or(EBADF)?
+        .get_socket()?
+        .ok_or(ENOTSOCK)?;
+
+    // FIXME: because tcp need to connect first, ignore to read dstaddr
+
+    let mut user_stream = CheckedUserPointer::new(buf, len).map(|ptr| ptr.into_stream())?;
+    Task::block_on(socket.send(&mut user_stream))
 }
 
 pub fn keep_alive() {}

--- a/src/kernel/task/loader/elf.rs
+++ b/src/kernel/task/loader/elf.rs
@@ -124,7 +124,7 @@ impl_elf_addr!(u32);
 impl_elf_addr!(u64);
 
 pub trait ElfArch {
-    type Ea: ElfAddr + Clone + Copy;
+    type Ea: ElfAddr + Clone + Copy + Send;
     type Ph: ProgramHeader + Clone + Copy + Default;
 
     const DYN_BASE_ADDR: usize;

--- a/src/kernel/timer.rs
+++ b/src/kernel/timer.rs
@@ -109,6 +109,10 @@ impl Instant {
     pub fn since_epoch(&self) -> Duration {
         Duration::new(self.secs_since_epoch, self.nsecs_within)
     }
+
+    pub fn to_millis(&self) -> u64 {
+        (self.secs_since_epoch * 1_000) + (self.nsecs_within / 1_000_000) as u64
+    }
 }
 
 impl From<Instant> for TimeSpec {

--- a/src/kernel/user/dataflow.rs
+++ b/src/kernel/user/dataflow.rs
@@ -16,6 +16,8 @@ pub struct CheckedUserPointer<'a> {
     _phantom: PhantomData<&'a ()>,
 }
 
+unsafe impl<'a> Send for CheckedUserPointer<'a> {}
+
 pub struct UserBuffer<'a> {
     ptr: CheckedUserPointer<'a>,
     size: usize,

--- a/src/kernel/vfs/filearray.rs
+++ b/src/kernel/vfs/filearray.rs
@@ -3,26 +3,33 @@ use super::{
     inode::Mode,
     s_ischr, Spin,
 };
-use crate::kernel::{
-    constants::{
-        EBADF, EISDIR, ENOTDIR, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD, F_SETFL,
-    },
-    syscall::{FromSyscallArg, SyscallRetVal},
-};
 use crate::{
     kernel::{
         console::get_console,
         constants::ENXIO,
-        vfs::{dentry::Dentry, file::Pipe, s_isdir, s_isreg},
+        vfs::{
+            dentry::Dentry,
+            file::{FileType, Pipe},
+            s_isdir, s_isreg,
+        },
         CharDevice,
     },
     prelude::*,
+};
+use crate::{
+    kernel::{
+        constants::{
+            EBADF, EISDIR, ENOTDIR, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_SETFD, F_SETFL,
+        },
+        syscall::{FromSyscallArg, SyscallRetVal},
+    },
+    net::socket::Socket,
 };
 use alloc::{
     collections::btree_map::{BTreeMap, Entry},
     sync::Arc,
 };
-use core::sync::atomic::Ordering;
+use core::sync::atomic::{AtomicU32, Ordering};
 use itertools::{
     FoldWhile::{Continue, Done},
     Itertools,
@@ -171,6 +178,17 @@ impl FileArray {
         inner.do_insert(write_fd, fdflag, write_end);
 
         Ok((read_fd, write_fd))
+    }
+
+    pub fn socket(&self, socket: Arc<dyn Socket>) -> KResult<FD> {
+        let mut inner = self.inner.lock();
+        let sockfd = inner.next_fd();
+        inner.do_insert(
+            sockfd,
+            FDFlags::default(),
+            File::new(OpenFlags::default(), FileType::Socket(socket)),
+        );
+        Ok(sockfd)
     }
 
     pub fn open(&self, dentry: &Arc<Dentry>, flags: OpenFlags, mode: Mode) -> KResult<FD> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(get_mut_unchecked)]
 #![feature(macro_metavar_expr)]
+#![feature(ip_from)]
 
 extern crate alloc;
 
@@ -145,7 +146,7 @@ async fn init_process(early_kstack: PRange) {
     {
         // We might want the serial initialized as soon as possible.
         driver::serial::init().unwrap();
-        driver::e1000e::register_e1000e_driver();
+        // driver::e1000e::register_e1000e_driver();
         driver::ahci::register_ahci_driver();
     }
 
@@ -153,7 +154,7 @@ async fn init_process(early_kstack: PRange) {
     {
         driver::serial::init().unwrap();
         driver::virtio::init_virtio_devices();
-        driver::e1000e::register_e1000e_driver();
+        // driver::e1000e::register_e1000e_driver();
         driver::ahci::register_ahci_driver();
         driver::goldfish_rtc::probe();
     }
@@ -162,9 +163,11 @@ async fn init_process(early_kstack: PRange) {
     {
         driver::serial::init().unwrap();
         driver::virtio::init_virtio_devices();
-        driver::e1000e::register_e1000e_driver();
+        // driver::e1000e::register_e1000e_driver();
         driver::ahci::register_ahci_driver();
     }
+
+    net::init().expect("Failed to initialize network");
 
     fs::tmpfs::init();
     fs::procfs::init();

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,1 +1,76 @@
+pub mod device;
+pub mod iface;
 pub mod netdev;
+pub mod socket;
+
+pub use device::register_netdev;
+
+use alloc::{sync::Arc, vec::Vec};
+use core::time::Duration;
+use eonix_log::println_warn;
+use eonix_runtime::{run::FutureRun, scheduler::Scheduler, task::Task};
+use eonix_sync::Mutex;
+use smoltcp::wire::{EthernetAddress, Ipv4Address, Ipv4Cidr};
+
+use crate::{
+    kernel::{task::KernelStack, timer::sleep},
+    net::{
+        device::NETDEVS,
+        iface::{Iface, IFACES},
+    },
+    prelude::KResult,
+};
+
+const VIRTIO_ADDRESS: Ipv4Address = Ipv4Address::new(10, 0, 2, 15);
+const VIRTIO_ADDRESS_PREFIX_LEN: u8 = 24;
+const VIRTIO_GATEWAY: Ipv4Address = Ipv4Address::new(10, 0, 2, 2);
+
+pub fn init() -> KResult<()> {
+    let netdevs = NETDEVS.lock();
+
+    // We don't supported dynamic registering network devices yet,
+    assert!(netdevs.len() > 0, "No network devices registered");
+
+    let mut ifaces = Vec::new();
+
+    for netdev in netdevs.values() {
+        let netdev_guard = netdev.lock();
+        let name = netdev_guard.name();
+        let ether_addr = netdev_guard.mac_addr();
+        drop(netdev_guard);
+
+        if name == "virtio_net" {
+            let iface = Iface::new(
+                netdev.clone(),
+                EthernetAddress(ether_addr),
+                Ipv4Cidr::new(VIRTIO_ADDRESS, VIRTIO_ADDRESS_PREFIX_LEN),
+                VIRTIO_GATEWAY,
+            );
+
+            ifaces.push(Arc::new(Mutex::new(iface)));
+        } else {
+            println_warn!("Currently only virtio_net is supported");
+        }
+    }
+
+    drop(netdevs);
+
+    Task::block_on(IFACES.lock()).extend(ifaces);
+
+    // Temporary scheduler task to poll network interfaces
+    // Better register a soft irq
+    Scheduler::get().spawn::<KernelStack, _>(FutureRun::new(async {
+        loop {
+            let ifaces = IFACES.lock().await;
+            for iface in ifaces.iter() {
+                let mut iface_guard = iface.lock().await;
+                iface_guard.poll();
+            }
+            drop(ifaces);
+
+            sleep(Duration::from_millis(100)).await;
+        }
+    }));
+
+    Ok(())
+}

--- a/src/net/device.rs
+++ b/src/net/device.rs
@@ -1,0 +1,114 @@
+use alloc::{
+    collections::btree_map::{BTreeMap, Entry},
+    sync::Arc,
+    vec,
+};
+
+use eonix_sync::Spin;
+
+use smoltcp::phy::DeviceCapabilities;
+pub use virtio_drivers::device::net::RxBuffer;
+
+use crate::{kernel::constants::EFAULT, prelude::KResult};
+
+pub type NetDevice = Arc<Spin<dyn NetDev>>;
+pub type Mac = [u8; 6];
+
+pub static NETDEVS: Spin<BTreeMap<&str, NetDevice>> = Spin::new(BTreeMap::new());
+
+pub fn register_netdev(netdev: impl NetDev + 'static) -> KResult<NetDevice> {
+    match NETDEVS.lock().entry(netdev.name()) {
+        Entry::Vacant(entry) => {
+            let netdev = Arc::new(Spin::new(netdev));
+            entry.insert(netdev.clone());
+            Ok(netdev)
+        }
+        Entry::Occupied(_) => Err(EFAULT),
+    }
+}
+
+pub fn get_netdev(name: &str) -> Option<NetDevice> {
+    NETDEVS.lock().get(name).map(|netdev| netdev.clone())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum NetDevError {
+    // NotReady,
+    // Busy,
+    Unknown,
+}
+
+pub trait NetDev: Send {
+    fn name(&self) -> &'static str;
+    fn mac_addr(&self) -> Mac;
+    fn caps(&self) -> DeviceCapabilities;
+
+    fn can_receive(&self) -> bool;
+    fn can_send(&self) -> bool;
+
+    fn recv(&mut self) -> Result<RxBuffer, NetDevError>;
+    fn send(&mut self, data: &[u8]) -> Result<(), NetDevError>;
+
+    // fn poll(&mut self);
+}
+
+impl smoltcp::phy::Device for dyn NetDev {
+    type RxToken<'a>
+        = RxToken
+    where
+        Self: 'a;
+
+    type TxToken<'a>
+        = TxToken<'a>
+    where
+        Self: 'a;
+
+    fn receive(
+        &mut self,
+        _timestamp: smoltcp::time::Instant,
+    ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        if self.can_receive() && self.can_send() {
+            let rx_buffer = self.recv().unwrap();
+            Some((RxToken(rx_buffer), TxToken(self)))
+        } else {
+            None
+        }
+    }
+
+    fn transmit(&mut self, _timestamp: smoltcp::time::Instant) -> Option<Self::TxToken<'_>> {
+        if self.can_send() {
+            Some(TxToken(self))
+        } else {
+            None
+        }
+    }
+
+    fn capabilities(&self) -> smoltcp::phy::DeviceCapabilities {
+        self.caps()
+    }
+}
+
+pub struct RxToken(RxBuffer);
+
+impl smoltcp::phy::RxToken for RxToken {
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        f(self.0.packet())
+    }
+}
+
+pub struct TxToken<'a>(&'a mut dyn NetDev);
+
+impl smoltcp::phy::TxToken for TxToken<'_> {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        let mut tx_data = vec![0; len];
+        let res = f(&mut tx_data);
+        self.0.send(&tx_data).expect("Send packet failed");
+        res
+    }
+}

--- a/src/net/iface.rs
+++ b/src/net/iface.rs
@@ -1,0 +1,146 @@
+use core::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use crate::kernel::constants::EADDRINUSE;
+use crate::kernel::timer::Instant;
+use crate::net::device::NetDevice;
+use crate::net::socket::tcp::TcpSocket;
+use crate::prelude::KResult;
+
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::{collections::btree_set::BTreeSet, vec::Vec};
+use eonix_runtime::task::Task;
+use eonix_sync::Mutex;
+use smoltcp::{
+    iface::{Config, Interface, SocketHandle, SocketSet},
+    socket::tcp,
+    wire::{self, EthernetAddress, Ipv4Cidr},
+};
+
+pub static IFACES: Mutex<Vec<NetIface>> = Mutex::new(Vec::new());
+
+pub type NetIface = Arc<Mutex<Iface>>;
+
+pub struct Iface {
+    device: NetDevice,
+    iface_inner: Interface,
+    // Should distinguish TCP/UDP ports
+    used_ports: BTreeSet<u16>,
+    sockets: SocketSet<'static>,
+}
+
+const IP_LOCAL_PORT_START: u16 = 32768;
+const IP_LOCAL_PORT_END: u16 = 60999;
+
+unsafe impl Send for Iface {}
+
+impl Iface {
+    pub fn new(
+        device: NetDevice,
+        ether_addr: EthernetAddress,
+        ip_cidr: Ipv4Cidr,
+        gateway: Ipv4Addr,
+    ) -> Self {
+        let iface_inner = {
+            let config = Config::new(wire::HardwareAddress::Ethernet(ether_addr));
+            let now = smoltcp::time::Instant::from_millis(Instant::now().to_millis() as i64);
+            let mut device = device.lock();
+            let mut iface = Interface::new(config, &mut *device, now);
+            iface.update_ip_addrs(|ip_addrs| ip_addrs.push(wire::IpCidr::Ipv4(ip_cidr)).unwrap());
+            iface.routes_mut().add_default_ipv4_route(gateway).unwrap();
+            iface
+        };
+
+        Self {
+            device,
+            iface_inner,
+            used_ports: BTreeSet::new(),
+            sockets: SocketSet::new(vec![]),
+        }
+    }
+
+    pub fn iface_and_sockets(&mut self) -> (&mut Interface, &mut SocketSet<'static>) {
+        (&mut self.iface_inner, &mut self.sockets)
+    }
+
+    fn new_tcp_socket(&mut self) -> SocketHandle {
+        let rx_buffer = tcp::SocketBuffer::new(vec![0; 1024]);
+        let tx_buffer = tcp::SocketBuffer::new(vec![0; 1024]);
+
+        self.sockets.add(tcp::Socket::new(rx_buffer, tx_buffer))
+    }
+
+    pub fn remove_tcp_socket(&mut self, socket: &TcpSocket) {
+        self.sockets
+            .remove(socket.handle().expect("Should have a socket handle"));
+
+        if let Some(socket_addr) = socket.local_addr() {
+            self.used_ports.remove(&socket_addr.port());
+        }
+    }
+
+    pub fn bind_tcp_socket(&mut self, bind_port: u16) -> KResult<(SocketAddr, SocketHandle)> {
+        if self.used_ports.contains(&bind_port) {
+            return Err(EADDRINUSE);
+        }
+
+        let port = if bind_port == 0 {
+            self.alloc_port().ok_or(EADDRINUSE)?
+        } else {
+            bind_port
+        };
+
+        let socket_addr = SocketAddr::new(
+            IpAddr::V4(self.iface_inner.ipv4_addr().expect("Set Ipv4 in construct")),
+            port,
+        );
+
+        let socket_handle = self.new_tcp_socket();
+
+        Ok((socket_addr, socket_handle))
+    }
+
+    fn alloc_port(&mut self) -> Option<u16> {
+        // FIXME: more efficient way to allocate ports
+        for port in IP_LOCAL_PORT_START..=IP_LOCAL_PORT_END {
+            if !self.used_ports.contains(&port) {
+                self.used_ports.insert(port);
+                return Some(port);
+            }
+        }
+        None
+    }
+
+    pub fn poll(&mut self) {
+        let mut device = self.device.lock();
+        let timestamp = smoltcp::time::Instant::from_millis(Instant::now().to_millis() as i64);
+
+        self.iface_inner
+            .poll(timestamp, &mut *device, &mut self.sockets);
+    }
+}
+
+pub fn get_relate_iface(ip_addr: IpAddr) -> Option<NetIface> {
+    let ifaces = Task::block_on(IFACES.lock());
+    for iface in ifaces.iter() {
+        let iface_guard = Task::block_on(iface.lock());
+        for cidr in iface_guard.iface_inner.ip_addrs() {
+            if IpAddr::from(cidr.address()) == ip_addr {
+                return Some(iface.clone());
+            }
+        }
+    }
+    None
+}
+
+pub fn get_ephemeral_iface(_remote_addr: Option<IpAddr>) -> Option<NetIface> {
+    let ifaces = Task::block_on(IFACES.lock());
+    assert!(ifaces.len() > 0, "No network interfaces available");
+
+    for iface in ifaces.iter() {
+        // FIXME: This is a temporary solution, we should select the best interface based on some criteria.
+        return Some(iface.clone());
+    }
+
+    None
+}

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -1,0 +1,85 @@
+use crate::{
+    io::{Buffer, Stream},
+    net::iface::NetIface,
+    prelude::KResult,
+};
+use alloc::{boxed::Box, sync::Arc};
+use async_trait::async_trait;
+use core::net::SocketAddr;
+use eonix_runtime::task::Task;
+use smoltcp::iface::SocketHandle;
+
+pub mod tcp;
+
+#[async_trait]
+pub trait Socket: Sync + Send {
+    fn bind(&self, _socket_addr: SocketAddr) -> KResult<()> {
+        panic!("Unimplemented");
+    }
+
+    fn listen(&self, _backlog: usize) -> KResult<()> {
+        panic!("Unimplemented");
+    }
+
+    async fn connect(&self, _remote_addr: SocketAddr) -> KResult<()> {
+        panic!("Unimplemented");
+    }
+
+    async fn accept(&self) -> KResult<(Arc<dyn Socket>, SocketAddr)> {
+        panic!("Unimplemented");
+    }
+
+    async fn recv(&self, buffer: &mut dyn Buffer) -> KResult<usize>;
+
+    async fn send(&self, stream: &mut dyn Stream) -> KResult<usize>;
+
+    fn close(&self) -> KResult<()> {
+        panic!("Unimplemented");
+    }
+}
+
+struct BoundSocket {
+    iface: NetIface,
+    socket_addr: SocketAddr,
+    socket_handle: SocketHandle,
+}
+
+impl BoundSocket {
+    pub fn new_bind(iface: NetIface, bind_port: Option<u16>) -> KResult<Self> {
+        let (socket_addr, socket_handle) = {
+            let mut iface_guard = Task::block_on(iface.lock());
+
+            iface_guard.bind_tcp_socket(bind_port.unwrap_or(0))?
+        };
+
+        Ok(Self {
+            iface,
+            socket_addr,
+            socket_handle,
+        })
+    }
+
+    pub fn new_accept(
+        iface: NetIface,
+        socket_handle: SocketHandle,
+        socket_addr: SocketAddr,
+    ) -> Self {
+        Self {
+            iface,
+            socket_addr,
+            socket_handle,
+        }
+    }
+
+    pub fn iface(&self) -> NetIface {
+        self.iface.clone()
+    }
+
+    pub fn handle(&self) -> SocketHandle {
+        self.socket_handle
+    }
+
+    pub fn socket_addr(&self) -> SocketAddr {
+        self.socket_addr
+    }
+}

--- a/src/net/socket/tcp.rs
+++ b/src/net/socket/tcp.rs
@@ -1,0 +1,329 @@
+use core::future::Future;
+use core::net::SocketAddr;
+use core::pin::Pin;
+use core::task::{Poll, Waker};
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use async_trait::async_trait;
+use eonix_runtime::task::Task;
+use eonix_sync::Mutex;
+use smoltcp::socket::tcp;
+use smoltcp::{iface::SocketHandle, wire::IpEndpoint};
+
+use crate::io::{Buffer, Stream};
+use crate::kernel::constants::{EADDRNOTAVAIL, EAGAIN, ECONNREFUSED, EINVAL, EISCONN, ENOTCONN};
+use crate::net::iface::{get_ephemeral_iface, get_relate_iface, NetIface};
+use crate::net::socket::{BoundSocket, Socket};
+use crate::prelude::KResult;
+
+pub struct TcpSocket {
+    bound_socket: Mutex<Option<BoundSocket>>,
+    is_nonblock: bool,
+}
+
+impl TcpSocket {
+    pub fn new(is_nonblock: bool) -> Arc<Self> {
+        Arc::new(Self {
+            bound_socket: Mutex::new(None),
+            is_nonblock,
+        })
+    }
+
+    fn iface(&self) -> Option<NetIface> {
+        Task::block_on(self.bound_socket.lock())
+            .as_ref()
+            .map(|bound_socket| bound_socket.iface())
+    }
+
+    pub fn handle(&self) -> Option<SocketHandle> {
+        Task::block_on(self.bound_socket.lock())
+            .as_ref()
+            .map(|bound_socket| bound_socket.handle())
+    }
+
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        Task::block_on(self.bound_socket.lock())
+            .as_ref()
+            .map(|bound_socket| bound_socket.socket_addr())
+    }
+
+    fn try_accept(&self, waker: &Waker) -> Option<KResult<(Arc<TcpSocket>, SocketAddr)>> {
+        let iface = self.iface().unwrap();
+
+        let mut iface_guard = Task::block_on(iface.lock());
+
+        let socket = iface_guard
+            .iface_and_sockets()
+            .1
+            .get_mut::<tcp::Socket>(self.handle().unwrap());
+
+        if socket.may_accept() {
+            match socket.accept() {
+                Ok(Some(new_socket)) => {
+                    let socket_addr = SocketAddr::from(new_socket.local_endpoint().unwrap());
+                    let remote_addr = SocketAddr::from(new_socket.remote_endpoint().unwrap());
+                    let handle = iface_guard.iface_and_sockets().1.add(new_socket);
+                    let accept_socket = Arc::new(TcpSocket {
+                        bound_socket: Mutex::new(Some(BoundSocket::new_accept(
+                            iface.clone(),
+                            handle,
+                            socket_addr,
+                        ))),
+                        is_nonblock: false,
+                    });
+                    Some(Ok((accept_socket, remote_addr)))
+                }
+                Ok(None) => {
+                    socket.register_recv_waker(waker);
+                    None
+                }
+                Err(_) => Some(Err(EINVAL)),
+            }
+        } else {
+            Some(Err(EINVAL))
+        }
+    }
+
+    fn try_recv(&self, buf: &mut dyn Buffer, waker: &Waker) -> Option<KResult<usize>> {
+        let iface = self.iface().unwrap();
+
+        let mut iface_guard = Task::block_on(iface.lock());
+
+        let socket = iface_guard
+            .iface_and_sockets()
+            .1
+            .get_mut::<tcp::Socket>(self.handle().unwrap());
+
+        if !socket.may_recv() {
+            Some(Err(ENOTCONN))
+        } else if socket.can_recv() {
+            let len = socket
+                .recv(|rx_data| {
+                    let _ = buf.fill(&rx_data[..]);
+                    (buf.wrote(), buf.wrote())
+                })
+                .unwrap(); // unwrap() is safe due to the source code logic
+            Some(Ok(len))
+        } else {
+            socket.register_recv_waker(waker);
+            None
+        }
+    }
+
+    fn try_send(&self, stream: &mut dyn Stream, waker: &Waker) -> Option<KResult<usize>> {
+        let iface = self.iface().unwrap();
+
+        let mut iface_guard = Task::block_on(iface.lock());
+
+        let socket = iface_guard
+            .iface_and_sockets()
+            .1
+            .get_mut::<tcp::Socket>(self.handle().unwrap());
+
+        if !socket.may_send() {
+            Some(Err(ENOTCONN))
+        } else if socket.can_send() {
+            let result = socket
+                .send(|tx_data| {
+                    let result = stream
+                        .poll_data(tx_data)
+                        .map(|data| data.map(|write_in| write_in.len()).unwrap_or(0));
+                    (result.unwrap_or(0), result)
+                })
+                .unwrap(); // unwrap() is safe due to the source code logic
+
+            Some(result)
+        } else {
+            socket.register_send_waker(waker);
+            None
+        }
+    }
+
+    fn check_connect(&self, waker: &Waker) -> Option<KResult<()>> {
+        let iface = self.iface().unwrap();
+
+        let mut iface_guard = Task::block_on(iface.lock());
+
+        let socket = iface_guard
+            .iface_and_sockets()
+            .1
+            .get_mut::<tcp::Socket>(self.handle().unwrap());
+
+        if socket.state() == tcp::State::Established {
+            Some(Ok(()))
+        } else if !socket.is_active() {
+            Some(Err(ECONNREFUSED))
+        } else {
+            socket.register_recv_waker(waker);
+            None
+        }
+    }
+}
+
+#[async_trait]
+impl Socket for TcpSocket {
+    fn bind(&self, socket_addr: SocketAddr) -> KResult<()> {
+        let mut bound_socket_guard = Task::block_on(self.bound_socket.lock());
+
+        if bound_socket_guard.is_some() {
+            return Err(EINVAL);
+        }
+
+        let bind_iface = get_relate_iface(socket_addr.ip()).ok_or(EADDRNOTAVAIL)?;
+
+        *bound_socket_guard = Some(BoundSocket::new_bind(bind_iface, Some(socket_addr.port()))?);
+
+        Ok(())
+    }
+
+    fn listen(&self, backlog: usize) -> KResult<()> {
+        let mut bound_socket_guard = Task::block_on(self.bound_socket.lock());
+
+        if bound_socket_guard.is_none() {
+            let bind_iface = get_ephemeral_iface(None);
+            *bound_socket_guard = Some(BoundSocket::new_bind(bind_iface.unwrap(), None)?);
+        }
+
+        drop(bound_socket_guard);
+
+        let iface = self.iface().unwrap();
+        let mut iface_guard = Task::block_on(iface.lock());
+
+        let socket = iface_guard
+            .iface_and_sockets()
+            .1
+            .get_mut::<tcp::Socket>(self.handle().unwrap());
+
+        socket
+            .listen(IpEndpoint::from(self.local_addr().unwrap()), Some(backlog))
+            .map_err(|_| EINVAL)?;
+
+        Ok(())
+    }
+
+    async fn connect(&self, remote_addr: SocketAddr) -> KResult<()> {
+        let mut bound_socket_guard = self.bound_socket.lock().await;
+
+        if bound_socket_guard.is_none() {
+            let bind_iface = get_ephemeral_iface(Some(remote_addr.ip()));
+            *bound_socket_guard = Some(BoundSocket::new_bind(bind_iface.unwrap(), None)?);
+        }
+
+        drop(bound_socket_guard);
+
+        let iface = self.iface().unwrap();
+        let mut iface_guard = iface.lock().await;
+
+        let (iface_inner, sockets) = iface_guard.iface_and_sockets();
+        let socket = sockets.get_mut::<tcp::Socket>(self.handle().unwrap());
+
+        socket
+            .connect(
+                iface_inner.context(),
+                IpEndpoint::from(remote_addr),
+                IpEndpoint::from(self.local_addr().unwrap()),
+            )
+            .map_err(|err| match err {
+                tcp::ConnectError::Unaddressable => EADDRNOTAVAIL,
+                // FIXME: Should return EISCONN ?
+                tcp::ConnectError::InvalidState => EISCONN,
+            })?;
+
+        drop(iface_guard);
+
+        struct ConnectFuture<'a> {
+            socket: &'a TcpSocket,
+        }
+
+        impl<'a> Future for ConnectFuture<'a> {
+            type Output = KResult<()>;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
+                let this = self.get_mut();
+                match this.socket.check_connect(cx.waker()) {
+                    Some(result) => Poll::Ready(result),
+                    None if this.socket.is_nonblock => Poll::Ready(Err(EAGAIN)),
+                    None => Poll::Pending,
+                }
+            }
+        }
+
+        ConnectFuture { socket: self }.await
+    }
+
+    async fn accept(&self) -> KResult<(Arc<dyn Socket>, SocketAddr)> {
+        struct AcceptFuture<'a> {
+            socket: &'a TcpSocket,
+        }
+
+        impl<'a> Future for AcceptFuture<'a> {
+            type Output = KResult<(Arc<dyn Socket>, SocketAddr)>;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
+                let this = self.get_mut();
+                match this.socket.try_accept(cx.waker()) {
+                    Some(result) => Poll::Ready(
+                        result.map(|(tcp_socket, remote_addr)| (tcp_socket as _, remote_addr)),
+                    ),
+                    None if this.socket.is_nonblock => Poll::Ready(Err(EAGAIN)),
+                    None => Poll::Pending,
+                }
+            }
+        }
+
+        AcceptFuture { socket: self }.await
+    }
+
+    async fn recv(&self, buffer: &mut dyn Buffer) -> KResult<usize> {
+        struct RecvFuture<'a> {
+            socket: &'a TcpSocket,
+            buffer: &'a mut dyn Buffer,
+        }
+
+        impl<'a> Future for RecvFuture<'a> {
+            type Output = KResult<usize>;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
+                let this = self.get_mut();
+                match this.socket.try_recv(this.buffer, cx.waker()) {
+                    Some(result) => Poll::Ready(result),
+                    None if this.socket.is_nonblock => Poll::Ready(Err(EAGAIN)),
+                    None => Poll::Pending,
+                }
+            }
+        }
+
+        RecvFuture {
+            socket: self,
+            buffer,
+        }
+        .await
+    }
+
+    async fn send(&self, stream: &mut dyn Stream) -> KResult<usize> {
+        struct SendFuture<'a> {
+            socket: &'a TcpSocket,
+            stream: &'a mut dyn Stream,
+        }
+
+        impl<'a> Future for SendFuture<'a> {
+            type Output = KResult<usize>;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
+                let this = self.get_mut();
+                match this.socket.try_send(this.stream, cx.waker()) {
+                    Some(result) => Poll::Ready(result),
+                    None if this.socket.is_nonblock => Poll::Ready(Err(EAGAIN)),
+                    None => Poll::Pending,
+                }
+            }
+        }
+
+        SendFuture {
+            socket: self,
+            stream,
+        }
+        .await
+    }
+}


### PR DESCRIPTION
Use customized smoltcp crate as our main network stack 
To fit with smoltcp, I abstract network implementation into device, iface, and socket. Now the net stack works fine running a simple tcp client or server with linux tap device. Some other protocols like udp and icmp need to be supported. And now e1000 is not refactored.
