### PR TITLE
syscall: fix struct termios definitions

### DIFF
--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -15,7 +15,7 @@ use posix_types::signal::Signal;
 
 const BUFFER_SIZE: usize = 4096;
 
-const NCCS: usize = 32;
+const NCCS: usize = 19;
 
 // taken from linux kernel code
 


### PR DESCRIPTION
Fixes the buffer overflow caused by the wrong struct size.


(cherry picked from commit de12291ceebab608e6ff89bf9e41a3ab479f19ce)